### PR TITLE
Replace "select" with "poll"

### DIFF
--- a/third_party/heimdal/lib/krb5/send_to_kdc.c
+++ b/third_party/heimdal/lib/krb5/send_to_kdc.c
@@ -969,8 +969,12 @@ submit_request(krb5_context context, krb5_sendto_ctx ctx, krb5_krbhst_info *hi)
 struct wait_ctx {
     krb5_context context;
     krb5_sendto_ctx ctx;
-    fd_set rfds;
-    fd_set wfds;
+    // fd_set rfds;
+    // fd_set wfds;
+
+	struct pollfd *fds;
+	int nfds;
+
     rk_socket_t max_fd;
     int got_reply;
     time_t timenow;
@@ -1006,22 +1010,35 @@ wait_setup(heim_object_t obj, void *iter_ctx, int *stop)
 	}
     }
     
-#ifndef NO_LIMIT_FD_SETSIZE
-    heim_assert(h->fd < FD_SETSIZE, "fd too large");
-#endif
+// #ifndef NO_LIMIT_FD_SETSIZE
+//     heim_assert(h->fd < FD_SETSIZE, "fd too large");
+// #endif
+
+	short flags = 0;
+
     switch (h->state) {
     case WAITING_REPLY:
-	FD_SET(h->fd, &wait_ctx->rfds);
+	//FD_SET(h->fd, &wait_ctx->rfds);
+	flags = POLLIN;
 	break;
     case CONNECTING:
     case CONNECTED:
-	FD_SET(h->fd, &wait_ctx->rfds);
-	FD_SET(h->fd, &wait_ctx->wfds);
+	// FD_SET(h->fd, &wait_ctx->rfds);
+	// FD_SET(h->fd, &wait_ctx->wfds);
+	flags = POLLIN | POLLOUT;
 	break;
     default:
 	debug_host(wait_ctx->context, 5, h, "invalid sendto host state");
 	heim_abort("invalid sendto host state");
     }
+
+	if (flags != 0) {
+		wait_ctx->fds[wait_ctx->nfds].fd = h->fd;
+		wait_ctx->fds[wait_ctx->nfds].events = flags;
+		wait_ctx->fds[wait_ctx->nfds].revents = 0;
+		wait_ctx->nfds++;
+	}
+
     if (h->fd > wait_ctx->max_fd || wait_ctx->max_fd == rk_INVALID_SOCKET)
 	wait_ctx->max_fd = h->fd;
 }
@@ -1050,11 +1067,28 @@ wait_process(heim_object_t obj, void *ctx, int *stop)
     int readable, writeable;
     heim_assert(h->state != DEAD, "dead host resurected");
 
-#ifndef NO_LIMIT_FD_SETSIZE
-    heim_assert(h->fd < FD_SETSIZE, "fd too large");
-#endif
-    readable = FD_ISSET(h->fd, &wait_ctx->rfds);
-    writeable = FD_ISSET(h->fd, &wait_ctx->wfds);
+// #ifndef NO_LIMIT_FD_SETSIZE
+//     heim_assert(h->fd < FD_SETSIZE, "fd too large");
+// #endif
+    // readable = FD_ISSET(h->fd, &wait_ctx->rfds);
+    // writeable = FD_ISSET(h->fd, &wait_ctx->wfds);
+
+	int fd_idx = -1;
+	for (int i = 0; i < wait_ctx->nfds; i++) {
+		if (wait_ctx->fds[i].fd == h->fd) {
+			fd_idx = i;
+			break;
+		}
+	}
+
+	if (fd_idx > -1) {
+		short flags = wait_ctx->fds[fd_idx].revents;
+		readable = flags & POLLIN;
+		writeable = flags & POLLOUT;
+	} else {
+		readable = 0;
+		writeable = 0;
+	}
 
     if (readable || writeable || h->state == CONNECT)
 	wait_ctx->got_reply |= eval_host_state(wait_ctx->context, wait_ctx->ctx, h, readable, writeable);
@@ -1076,6 +1110,10 @@ wait_response(krb5_context context, int *action, krb5_sendto_ctx ctx)
     FD_ZERO(&wait_ctx.rfds);
     FD_ZERO(&wait_ctx.wfds);
     wait_ctx.max_fd = rk_INVALID_SOCKET;
+	
+	struct pollfd fds[heim_array_get_length(ctx->hosts)];
+	wait_ctx.fds = &fds;
+	wait_ctx.nfds = 0;
 
     /* oh, we have a reply, it must be a plugin that got it for us */
     if (ctx->response.length) {
@@ -1115,7 +1153,9 @@ wait_response(krb5_context context, int *action, krb5_sendto_ctx ctx)
     tv.tv_sec = 1;
     tv.tv_usec = 0;
 
-    ret = select(wait_ctx.max_fd + 1, &wait_ctx.rfds, &wait_ctx.wfds, NULL, &tv);
+    //ret = select(wait_ctx.max_fd + 1, &wait_ctx.rfds, &wait_ctx.wfds, NULL, &tv);
+
+	ret = poll(wait_ctx.fds, wait_ctx.nfds, tv.tv_sec * 1000 + tv.tv_usec / 1000);
     if (ret < 0)
 	return errno;
     if (ret == 0) {

--- a/third_party/heimdal/lib/krb5/send_to_kdc.c
+++ b/third_party/heimdal/lib/krb5/send_to_kdc.c
@@ -1112,7 +1112,7 @@ wait_response(krb5_context context, int *action, krb5_sendto_ctx ctx)
     wait_ctx.max_fd = rk_INVALID_SOCKET;
 	
     struct pollfd fds[heim_array_get_length(ctx->hosts)];
-    wait_ctx.fds = &fds;
+    wait_ctx.fds = fds;
     wait_ctx.nfds = 0;
 
     /* oh, we have a reply, it must be a plugin that got it for us */

--- a/third_party/heimdal/lib/krb5/send_to_kdc.c
+++ b/third_party/heimdal/lib/krb5/send_to_kdc.c
@@ -891,13 +891,6 @@ submit_request(krb5_context context, krb5_sendto_ctx ctx, krb5_krbhst_info *hi)
 	    continue;
 	rk_cloexec(fd);
 
-#ifndef NO_LIMIT_FD_SETSIZE
-	if (fd >= FD_SETSIZE) {
-	    _krb5_debug(context, 0, "fd too large for select");
-	    rk_closesocket(fd);
-	    continue;
-	}
-#endif
 	socket_set_nonblocking(fd, 1);
 
 	host = heim_alloc(sizeof(*host), "sendto-host", deallocate_host);
@@ -969,8 +962,6 @@ submit_request(krb5_context context, krb5_sendto_ctx ctx, krb5_krbhst_info *hi)
 struct wait_ctx {
     krb5_context context;
     krb5_sendto_ctx ctx;
-    // fd_set rfds;
-    // fd_set wfds;
 
     struct pollfd *fds;
     int nfds;
@@ -1009,22 +1000,15 @@ wait_setup(heim_object_t obj, void *iter_ctx, int *stop)
 	    host_connected(wait_ctx->context, wait_ctx->ctx, h);
 	}
     }
-    
-// #ifndef NO_LIMIT_FD_SETSIZE
-//     heim_assert(h->fd < FD_SETSIZE, "fd too large");
-// #endif
 
     short flags = 0;
 
     switch (h->state) {
     case WAITING_REPLY:
-	//FD_SET(h->fd, &wait_ctx->rfds);
 	flags = POLLIN;
 	break;
     case CONNECTING:
     case CONNECTED:
-	// FD_SET(h->fd, &wait_ctx->rfds);
-	// FD_SET(h->fd, &wait_ctx->wfds);
 	flags = POLLIN | POLLOUT;
 	break;
     default:
@@ -1068,12 +1052,6 @@ wait_process(heim_object_t obj, void *ctx, int *stop)
     int readable, writeable;
     heim_assert(h->state != DEAD, "dead host resurected");
 
-// #ifndef NO_LIMIT_FD_SETSIZE
-//     heim_assert(h->fd < FD_SETSIZE, "fd too large");
-// #endif
-    // readable = FD_ISSET(h->fd, &wait_ctx->rfds);
-    // writeable = FD_ISSET(h->fd, &wait_ctx->wfds);
-
     int fd_idx = -1;
     for (int i = 0; i < wait_ctx->nfds; i++) {
         if (wait_ctx->fds[i].fd == h->fd) {
@@ -1108,8 +1086,6 @@ wait_response(krb5_context context, int *action, krb5_sendto_ctx ctx)
 
     wait_ctx.context = context;
     wait_ctx.ctx = ctx;
-    FD_ZERO(&wait_ctx.rfds);
-    FD_ZERO(&wait_ctx.wfds);
     wait_ctx.max_fd = rk_INVALID_SOCKET;
 	
     struct pollfd fds[heim_array_get_length(ctx->hosts)];
@@ -1153,8 +1129,6 @@ wait_response(krb5_context context, int *action, krb5_sendto_ctx ctx)
 
     tv.tv_sec = 1;
     tv.tv_usec = 0;
-
-    //ret = select(wait_ctx.max_fd + 1, &wait_ctx.rfds, &wait_ctx.wfds, NULL, &tv);
 
     ret = poll(wait_ctx.fds, wait_ctx.nfds, tv.tv_sec * 1000 + tv.tv_usec / 1000);
     if (ret < 0)

--- a/third_party/heimdal/lib/krb5/send_to_kdc.c
+++ b/third_party/heimdal/lib/krb5/send_to_kdc.c
@@ -972,8 +972,8 @@ struct wait_ctx {
     // fd_set rfds;
     // fd_set wfds;
 
-	struct pollfd *fds;
-	int nfds;
+    struct pollfd *fds;
+    int nfds;
 
     rk_socket_t max_fd;
     int got_reply;
@@ -1014,7 +1014,7 @@ wait_setup(heim_object_t obj, void *iter_ctx, int *stop)
 //     heim_assert(h->fd < FD_SETSIZE, "fd too large");
 // #endif
 
-	short flags = 0;
+    short flags = 0;
 
     switch (h->state) {
     case WAITING_REPLY:
@@ -1032,12 +1032,12 @@ wait_setup(heim_object_t obj, void *iter_ctx, int *stop)
 	heim_abort("invalid sendto host state");
     }
 
-	if (flags != 0) {
-		wait_ctx->fds[wait_ctx->nfds].fd = h->fd;
-		wait_ctx->fds[wait_ctx->nfds].events = flags;
-		wait_ctx->fds[wait_ctx->nfds].revents = 0;
-		wait_ctx->nfds++;
-	}
+    if (flags != 0) {
+    wait_ctx->fds[wait_ctx->nfds].fd = h->fd;
+    wait_ctx->fds[wait_ctx->nfds].events = flags;
+    wait_ctx->fds[wait_ctx->nfds].revents = 0;
+    wait_ctx->nfds++;
+    }
 
     if (h->fd > wait_ctx->max_fd || wait_ctx->max_fd == rk_INVALID_SOCKET)
 	wait_ctx->max_fd = h->fd;
@@ -1073,22 +1073,22 @@ wait_process(heim_object_t obj, void *ctx, int *stop)
     // readable = FD_ISSET(h->fd, &wait_ctx->rfds);
     // writeable = FD_ISSET(h->fd, &wait_ctx->wfds);
 
-	int fd_idx = -1;
-	for (int i = 0; i < wait_ctx->nfds; i++) {
-		if (wait_ctx->fds[i].fd == h->fd) {
-			fd_idx = i;
-			break;
-		}
-	}
+    int fd_idx = -1;
+    for (int i = 0; i < wait_ctx->nfds; i++) {
+        if (wait_ctx->fds[i].fd == h->fd) {
+        fd_idx = i;
+        break;
+        }
+    }
 
-	if (fd_idx > -1) {
-		short flags = wait_ctx->fds[fd_idx].revents;
-		readable = flags & POLLIN;
-		writeable = flags & POLLOUT;
-	} else {
-		readable = 0;
-		writeable = 0;
-	}
+    if (fd_idx > -1) {
+    short flags = wait_ctx->fds[fd_idx].revents;
+    readable = flags & POLLIN;
+    writeable = flags & POLLOUT;
+    } else {
+    readable = 0;
+    writeable = 0;
+    }
 
     if (readable || writeable || h->state == CONNECT)
 	wait_ctx->got_reply |= eval_host_state(wait_ctx->context, wait_ctx->ctx, h, readable, writeable);
@@ -1111,9 +1111,9 @@ wait_response(krb5_context context, int *action, krb5_sendto_ctx ctx)
     FD_ZERO(&wait_ctx.wfds);
     wait_ctx.max_fd = rk_INVALID_SOCKET;
 	
-	struct pollfd fds[heim_array_get_length(ctx->hosts)];
-	wait_ctx.fds = &fds;
-	wait_ctx.nfds = 0;
+    struct pollfd fds[heim_array_get_length(ctx->hosts)];
+    wait_ctx.fds = &fds;
+    wait_ctx.nfds = 0;
 
     /* oh, we have a reply, it must be a plugin that got it for us */
     if (ctx->response.length) {
@@ -1155,7 +1155,7 @@ wait_response(krb5_context context, int *action, krb5_sendto_ctx ctx)
 
     //ret = select(wait_ctx.max_fd + 1, &wait_ctx.rfds, &wait_ctx.wfds, NULL, &tv);
 
-	ret = poll(wait_ctx.fds, wait_ctx.nfds, tv.tv_sec * 1000 + tv.tv_usec / 1000);
+    ret = poll(wait_ctx.fds, wait_ctx.nfds, tv.tv_sec * 1000 + tv.tv_usec / 1000);
     if (ret < 0)
 	return errno;
     if (ret == 0) {

--- a/third_party/heimdal/lib/krb5/send_to_kdc.c
+++ b/third_party/heimdal/lib/krb5/send_to_kdc.c
@@ -1064,6 +1064,7 @@ wait_process(heim_object_t obj, void *ctx, int *stop)
 {
     struct wait_ctx *wait_ctx = ctx;
     struct host *h = (struct host *)obj;
+	int flags;
     int readable, writeable;
     heim_assert(h->state != DEAD, "dead host resurected");
 


### PR DESCRIPTION
Replaces "select" C lib call with poll. File descriptors routinely come back > 1024 when running in Skysync. Select api can't handle this so replaced with poll.