### PR TITLE
Disable validation on client realm

### DIFF
--- a/auth/gensec/gensec_util.c
+++ b/auth/gensec/gensec_util.c
@@ -394,10 +394,6 @@ NTSTATUS gensec_kerberos_possible(struct gensec_security *gensec_security)
 		return NT_STATUS_OK;
 	}
 
-	if (client_realm == NULL) {
-		return NT_STATUS_INVALID_PARAMETER;
-	}
-
 	if (hostname == NULL) {
 		return NT_STATUS_INVALID_PARAMETER;
 	}


### PR DESCRIPTION
Realm was being validated as required even though there is no way to pass that in to libsmbclient. Samba auto-determines realm based on the user account name anyhow so doesn't need this.